### PR TITLE
Module outputs, StorageClass default and required variable updates

### DIFF
--- a/.terraform-docs.yml
+++ b/.terraform-docs.yml
@@ -11,10 +11,8 @@ content: |-
   3. A public Route53 DNS Zone: This module will create DNS records for the Wayfinder API and UI endpoints, and performs a DNS01 challenge via the LetsEncrypt Issuer for valid domain certificates.
   4. Existing VPC and Subnets: This module will deploy an EKS Cluster and so requires an existing VPC with outbound internet connectivity. Public ingress is not required, both EKS and Wayfinder ingress can be configured with an internal endpoint.
   5. Network Resource Tags: Tags are required to select the correct networking resources:
-    1. The VPC should have a tag to identify it is for Wayfinder use, e.g. `"Name" = "wayfinder-production"`
-    2. Public Subnets should have the tag `"kubernetes.io/role/elb" = 1`
-    3. Private Subnets should have the tag `"kubernetes.io/role/internal-elb" = 1`
-    4. Private Subnets should have a tag to identify they are not publicly accessible, e.g. `"Tier" = "private"`
+    1. Public Subnets should have the tag `"kubernetes.io/role/elb" = 1`
+    2. Private Subnets should have the tag `"kubernetes.io/role/internal-elb" = 1`
 
   ### Wayfinder License and IDP Secret
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="output_cluster_certificate_authority_data"></a> [cluster\_certificate\_authority\_data](#output\_cluster\_certificate\_authority\_data) | The base64 encoded certificate data for the Wayfinder EKS cluster |
 | <a name="output_cluster_endpoint"></a> [cluster\_endpoint](#output\_cluster\_endpoint) | The endpoint for the Wayfinder EKS Kubernetes API |
 | <a name="output_cluster_name"></a> [cluster\_name](#output\_cluster\_name) | The name of the Wayfinder EKS cluster |
+| <a name="output_cluster_oidc_provider_arn"></a> [cluster\_oidc\_provider\_arn](#output\_cluster\_oidc\_provider\_arn) | The ARN of the OIDC provider for the Wayfinder EKS cluster |
 | <a name="output_wayfinder_api_url"></a> [wayfinder\_api\_url](#output\_wayfinder\_api\_url) | The URL for the Wayfinder API |
 | <a name="output_wayfinder_iam_role_arn"></a> [wayfinder\_iam\_role\_arn](#output\_wayfinder\_iam\_role\_arn) | The ARN of the IAM role used by Wayfinder |
 | <a name="output_wayfinder_instance_identifier"></a> [wayfinder\_instance\_identifier](#output\_wayfinder\_instance\_identifier) | The unique identifier for the Wayfinder instance |

--- a/README.md
+++ b/README.md
@@ -11,10 +11,8 @@ To run this module, you will need the following:
 3. A public Route53 DNS Zone: This module will create DNS records for the Wayfinder API and UI endpoints, and performs a DNS01 challenge via the LetsEncrypt Issuer for valid domain certificates.
 4. Existing VPC and Subnets: This module will deploy an EKS Cluster and so requires an existing VPC with outbound internet connectivity. Public ingress is not required, both EKS and Wayfinder ingress can be configured with an internal endpoint.
 5. Network Resource Tags: Tags are required to select the correct networking resources:
-1. The VPC should have a tag to identify it is for Wayfinder use, e.g. `"Name" = "wayfinder-production"`
-2. Public Subnets should have the tag `"kubernetes.io/role/elb" = 1`
-3. Private Subnets should have the tag `"kubernetes.io/role/internal-elb" = 1`
-4. Private Subnets should have a tag to identify they are not publicly accessible, e.g. `"Tier" = "private"`
+1. Public Subnets should have the tag `"kubernetes.io/role/elb" = 1`
+2. Private Subnets should have the tag `"kubernetes.io/role/internal-elb" = 1`
 
 ### Wayfinder License and IDP Secret
 
@@ -61,8 +59,8 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="input_kms_key_administrators"></a> [kms\_key\_administrators](#input\_kms\_key\_administrators) | A list of IAM ARNs for EKS key administrators. If no value is provided, the current caller identity is used to ensure at least one key admin is available | `list(string)` | `[]` | no |
 | <a name="input_kube_proxy_addon_version"></a> [kube\_proxy\_addon\_version](#input\_kube\_proxy\_addon\_version) | Kube Proxy Addon version to use | `string` | `"v1.24.7-eksbuild.2"` | no |
 | <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |
-| <a name="input_subnet_tags"></a> [subnet\_tags](#input\_subnet\_tags) | The tags to use for subnet selection | `map(string)` | <pre>{<br>  "Tier": "Private"<br>}</pre> | no |
-| <a name="input_vpc_tags"></a> [vpc\_tags](#input\_vpc\_tags) | The tags to use for VPC selection | `map(string)` | <pre>{<br>  "Name": "wayfinder"<br>}</pre> | no |
+| <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of private Subnet IDs to launch the Wayfinder EKS Nodes onto | `list(string)` | n/a | yes |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the Wayfinder EKS Cluster to be built within | `string` | n/a | yes |
 | <a name="input_wayfinder_domain_name_api"></a> [wayfinder\_domain\_name\_api](#input\_wayfinder\_domain\_name\_api) | The domain name to use for the Wayfinder API (e.g. api.wayfinder.example.com) | `string` | n/a | yes |
 | <a name="input_wayfinder_domain_name_ui"></a> [wayfinder\_domain\_name\_ui](#input\_wayfinder\_domain\_name\_ui) | The domain name to use for the Wayfinder UI (e.g. portal.wayfinder.example.com) | `string` | n/a | yes |
 | <a name="input_wayfinder_release_channel"></a> [wayfinder\_release\_channel](#input\_wayfinder\_release\_channel) | The release channel to use for Wayfinder | `string` | `"wayfinder-releases"` | no |

--- a/eks.tf
+++ b/eks.tf
@@ -10,8 +10,8 @@ module "eks" {
   cluster_endpoint_public_access       = !var.disable_internet_access
   cluster_endpoint_public_access_cidrs = var.cluster_endpoint_public_access_cidrs
   kms_key_administrators               = var.kms_key_administrators
-  subnet_ids                           = data.aws_subnets.private.ids
-  vpc_id                               = data.aws_vpc.selected.id
+  subnet_ids                           = var.subnet_ids
+  vpc_id                               = var.vpc_id
 
   cluster_addons = {
     coredns = {

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -11,16 +11,10 @@ module "wayfinder" {
   eks_ng_minimum_size                     = 2
   environment                             = "prod"
   kms_key_administrators                  = ["arn:aws:iam::111222333444:root"]
+  subnet_ids                              = ["subnet-123", "subnet-456", "subnet-789"]
+  vpc_id                                  = "vpc-1a2b3c4d5e"
   wayfinder_domain_name_api               = "api.wayfinder.example.com"
   wayfinder_domain_name_ui                = "portal.wayfinder.example.com"
-
-  vpc_tags                                = {
-    "Name" = "wayfinder-prod"
-  }
-
-  subnet_tags                             = {
-    "Tier" = "Private"
-  }
 
   cluster_security_group_additional_rules = {
     allow_access_from_vpn = {

--- a/main.tf
+++ b/main.tf
@@ -1,19 +1,6 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 
-data "aws_vpc" "selected" {
-  tags = var.vpc_tags
-}
-
-data "aws_subnets" "private" {
-  filter {
-    name   = "vpc-id"
-    values = [data.aws_vpc.selected.id]
-  }
-
-  tags = var.subnet_tags
-}
-
 locals {
   name = format("wayfinder-%s", var.environment)
 

--- a/manifests/storageclass.yml.tpl
+++ b/manifests/storageclass.yml.tpl
@@ -1,0 +1,12 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  name: ${name}
+parameters:
+  fsType: ext4
+  type: gp2
+provisioner: kubernetes.io/aws-ebs
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/outputs.tf
+++ b/outputs.tf
@@ -13,6 +13,11 @@ output "cluster_name" {
   value       = module.eks.cluster_name
 }
 
+output "cluster_oidc_provider_arn" {
+  description = "The ARN of the OIDC provider for the Wayfinder EKS cluster"
+  value       = module.eks.oidc_provider_arn
+}
+
 output "wayfinder_api_url" {
   description = "The URL for the Wayfinder API"
   value       = "https://${var.wayfinder_domain_name_api}"

--- a/variables.tf
+++ b/variables.tf
@@ -80,20 +80,14 @@ variable "node_security_group_additional_rules" {
   default     = {}
 }
 
-variable "subnet_tags" {
-  description = "The tags to use for subnet selection"
-  type        = map(string)
-  default = {
-    Tier = "Private"
-  }
+variable "subnet_ids" {
+  description = "A list of private Subnet IDs to launch the Wayfinder EKS Nodes onto"
+  type        = list(string)
 }
 
-variable "vpc_tags" {
-  description = "The tags to use for VPC selection"
-  type        = map(string)
-  default = {
-    Name = "wayfinder"
-  }
+variable "vpc_id" {
+  description = "The VPC ID for the Wayfinder EKS Cluster to be built within"
+  type        = string
 }
 
 variable "wayfinder_domain_name_api" {

--- a/wayfinder.tf
+++ b/wayfinder.tf
@@ -10,6 +10,16 @@ data "aws_secretsmanager_secret_version" "wayfinder" {
   secret_id = data.aws_secretsmanager_secret.wayfinder.id
 }
 
+resource "kubectl_manifest" "storageclass" {
+  depends_on = [
+    module.eks,
+  ]
+
+  yaml_body = templatefile("${path.module}/manifests/storageclass.yml.tpl", {
+    name = "gp2"
+  })
+}
+
 resource "kubectl_manifest" "storageclass_encrypted" {
   depends_on = [
     module.eks,


### PR DESCRIPTION
**Required changes:**
The variables `subnet_tags` and `vpc_tags` have been replaced with `subnet_ids` and `vpc_id`. This change was done to address complications with data lookups (when this module is called in the same root module that is creating the VPC and Subnets).

**Change list:**
1. Add the `cluster_oidc_provider_arn` output
2. Ensure only one StorageClass is marked as the default
3. Avoid using data lookups for VPC and Subnet IDs