### PR TITLE
Wayfinder v2.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,13 +41,14 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_aws_ebs_csi_driver_addon_version"></a> [aws\_ebs\_csi\_driver\_addon\_version](#input\_aws\_ebs\_csi\_driver\_addon\_version) | The version to use for the AWS EBS CSI driver | `string` | `"v1.18.0-eksbuild.1"` | no |
+| <a name="input_aws_ebs_csi_driver_addon_version"></a> [aws\_ebs\_csi\_driver\_addon\_version](#input\_aws\_ebs\_csi\_driver\_addon\_version) | The version to use for the AWS EBS CSI driver | `string` | `"v1.19.0-eksbuild.2"` | no |
 | <a name="input_aws_secretsmanager_name"></a> [aws\_secretsmanager\_name](#input\_aws\_secretsmanager\_name) | The name of the AWS Secrets Manager secret to use for Wayfinder. Must already exist and contain: 'licenseKey', 'idpClientId', 'idpClientSecret', 'idpServerUrl' | `string` | `"wayfinder-secrets"` | no |
-| <a name="input_aws_vpc_cni_addon_version"></a> [aws\_vpc\_cni\_addon\_version](#input\_aws\_vpc\_cni\_addon\_version) | AWS VPC CNI Addon version to use | `string` | `"v1.11.4-eksbuild.1"` | no |
+| <a name="input_aws_vpc_cni_addon_version"></a> [aws\_vpc\_cni\_addon\_version](#input\_aws\_vpc\_cni\_addon\_version) | AWS VPC CNI Addon version to use | `string` | `"v1.12.6-eksbuild.2"` | no |
 | <a name="input_cluster_endpoint_public_access_cidrs"></a> [cluster\_endpoint\_public\_access\_cidrs](#input\_cluster\_endpoint\_public\_access\_cidrs) | List of CIDR blocks which can access the Amazon EKS API server endpoint | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_cluster_security_group_additional_rules"></a> [cluster\_security\_group\_additional\_rules](#input\_cluster\_security\_group\_additional\_rules) | List of additional security group rules to add to the cluster security group created. Set `source_node_security_group = true` inside rules to set the `node_security_group` as source | `any` | `{}` | no |
+| <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The Kubernetes version to use for the EKS cluster | `string` | `"1.25"` | no |
 | <a name="input_clusterissuer_email"></a> [clusterissuer\_email](#input\_clusterissuer\_email) | The email address to use for the cert-manager cluster issuer | `string` | n/a | yes |
-| <a name="input_coredns_addon_version"></a> [coredns\_addon\_version](#input\_coredns\_addon\_version) | CoreDNS Addon version to use | `string` | `"v1.8.7-eksbuild.3"` | no |
+| <a name="input_coredns_addon_version"></a> [coredns\_addon\_version](#input\_coredns\_addon\_version) | CoreDNS Addon version to use | `string` | `"v1.9.3-eksbuild.5"` | no |
 | <a name="input_disable_internet_access"></a> [disable\_internet\_access](#input\_disable\_internet\_access) | Whether to disable internet access for EKS and the Wayfinder ingress controller | `bool` | `false` | no |
 | <a name="input_dns_zone_name"></a> [dns\_zone\_name](#input\_dns\_zone\_name) | The local DNS zone to use (e.g. wayfinder.example.com) | `string` | n/a | yes |
 | <a name="input_ebs_csi_kms_cmk_ids"></a> [ebs\_csi\_kms\_cmk\_ids](#input\_ebs\_csi\_kms\_cmk\_ids) | List of KMS CMKs to allow EBS CSI to manage encrypted volumes. This is required if EBS encryption is set at the account level with a default KMS CMK. | `list(string)` | `[]` | no |
@@ -57,14 +58,14 @@ The `terraform-docs` utility is used to generate this README. Follow the below s
 | <a name="input_eks_ng_minimum_size"></a> [eks\_ng\_minimum\_size](#input\_eks\_ng\_minimum\_size) | The minimum size to use for the EKS managed node group | `number` | `2` | no |
 | <a name="input_environment"></a> [environment](#input\_environment) | The environment name we are provisioning | `string` | `"production"` | no |
 | <a name="input_kms_key_administrators"></a> [kms\_key\_administrators](#input\_kms\_key\_administrators) | A list of IAM ARNs for EKS key administrators. If no value is provided, the current caller identity is used to ensure at least one key admin is available | `list(string)` | `[]` | no |
-| <a name="input_kube_proxy_addon_version"></a> [kube\_proxy\_addon\_version](#input\_kube\_proxy\_addon\_version) | Kube Proxy Addon version to use | `string` | `"v1.24.7-eksbuild.2"` | no |
+| <a name="input_kube_proxy_addon_version"></a> [kube\_proxy\_addon\_version](#input\_kube\_proxy\_addon\_version) | Kube Proxy Addon version to use | `string` | `"v1.25.9-eksbuild.1"` | no |
 | <a name="input_node_security_group_additional_rules"></a> [node\_security\_group\_additional\_rules](#input\_node\_security\_group\_additional\_rules) | List of additional security group rules to add to the node security group created. Set `source_cluster_security_group = true` inside rules to set the `cluster_security_group` as source | `any` | `{}` | no |
 | <a name="input_subnet_ids"></a> [subnet\_ids](#input\_subnet\_ids) | A list of private Subnet IDs to launch the Wayfinder EKS Nodes onto | `list(string)` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC ID for the Wayfinder EKS Cluster to be built within | `string` | n/a | yes |
 | <a name="input_wayfinder_domain_name_api"></a> [wayfinder\_domain\_name\_api](#input\_wayfinder\_domain\_name\_api) | The domain name to use for the Wayfinder API (e.g. api.wayfinder.example.com) | `string` | n/a | yes |
 | <a name="input_wayfinder_domain_name_ui"></a> [wayfinder\_domain\_name\_ui](#input\_wayfinder\_domain\_name\_ui) | The domain name to use for the Wayfinder UI (e.g. portal.wayfinder.example.com) | `string` | n/a | yes |
 | <a name="input_wayfinder_release_channel"></a> [wayfinder\_release\_channel](#input\_wayfinder\_release\_channel) | The release channel to use for Wayfinder | `string` | `"wayfinder-releases"` | no |
-| <a name="input_wayfinder_version"></a> [wayfinder\_version](#input\_wayfinder\_version) | The version to use for Wayfinder | `string` | `"v2.0.5"` | no |
+| <a name="input_wayfinder_version"></a> [wayfinder\_version](#input\_wayfinder\_version) | The version to use for Wayfinder | `string` | `"v2.1.1"` | no |
 
 ## Outputs
 

--- a/eks.tf
+++ b/eks.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.13.0"
 
   cluster_name    = local.name
-  cluster_version = "1.24"
+  cluster_version = var.cluster_version
   tags            = local.tags
 
   cluster_endpoint_private_access      = true

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -1,20 +1,20 @@
 module "wayfinder" {
   source = "../"
 
-  aws_secretsmanager_name                 = "wayfinder-prod-secrets"
-  clusterissuer_email                     = "certmanager-notifications@example.com"
-  disable_internet_access                 = true
-  dns_zone_name                           = "wayfinder.example.com"
-  eks_ng_capacity_type                    = "ON_DEMAND"
-  eks_ng_desired_size                     = 2
-  eks_ng_instance_types                   = ["t3.xlarge"]
-  eks_ng_minimum_size                     = 2
-  environment                             = "prod"
-  kms_key_administrators                  = ["arn:aws:iam::111222333444:root"]
-  subnet_ids                              = ["subnet-123", "subnet-456", "subnet-789"]
-  vpc_id                                  = "vpc-1a2b3c4d5e"
-  wayfinder_domain_name_api               = "api.wayfinder.example.com"
-  wayfinder_domain_name_ui                = "portal.wayfinder.example.com"
+  aws_secretsmanager_name   = "wayfinder-prod-secrets"
+  clusterissuer_email       = "certmanager-notifications@example.com"
+  disable_internet_access   = true
+  dns_zone_name             = "wayfinder.example.com"
+  eks_ng_capacity_type      = "ON_DEMAND"
+  eks_ng_desired_size       = 2
+  eks_ng_instance_types     = ["t3.xlarge"]
+  eks_ng_minimum_size       = 2
+  environment               = "prod"
+  kms_key_administrators    = ["arn:aws:iam::111222333444:root"]
+  subnet_ids                = ["subnet-123", "subnet-456", "subnet-789"]
+  vpc_id                    = "vpc-1a2b3c4d5e"
+  wayfinder_domain_name_api = "api.wayfinder.example.com"
+  wayfinder_domain_name_ui  = "portal.wayfinder.example.com"
 
   cluster_security_group_additional_rules = {
     allow_access_from_vpn = {

--- a/examples/terraform.tf
+++ b/examples/terraform.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.62"
+    }
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.19.0"
+    }
+  }
+}

--- a/variables.tf
+++ b/variables.tf
@@ -21,6 +21,12 @@ variable "cluster_security_group_additional_rules" {
   default     = {}
 }
 
+variable "cluster_version" {
+  description = "The Kubernetes version to use for the EKS cluster"
+  type        = string
+  default     = "1.25"
+}
+
 variable "disable_internet_access" {
   description = "Whether to disable internet access for EKS and the Wayfinder ingress controller"
   type        = bool
@@ -109,29 +115,29 @@ variable "wayfinder_release_channel" {
 variable "wayfinder_version" {
   description = "The version to use for Wayfinder"
   type        = string
-  default     = "v2.0.5"
+  default     = "v2.1.1"
 }
 
 variable "aws_ebs_csi_driver_addon_version" {
   description = "The version to use for the AWS EBS CSI driver"
   type        = string
-  default     = "v1.18.0-eksbuild.1"
+  default     = "v1.19.0-eksbuild.2"
 }
 
 variable "coredns_addon_version" {
   description = "CoreDNS Addon version to use"
   type        = string
-  default     = "v1.8.7-eksbuild.3"
+  default     = "v1.9.3-eksbuild.5"
 }
 
 variable "kube_proxy_addon_version" {
   description = "Kube Proxy Addon version to use"
   type        = string
-  default     = "v1.24.7-eksbuild.2"
+  default     = "v1.25.9-eksbuild.1"
 }
 
 variable "aws_vpc_cni_addon_version" {
   description = "AWS VPC CNI Addon version to use"
   type        = string
-  default     = "v1.11.4-eksbuild.1"
+  default     = "v1.12.6-eksbuild.2"
 }


### PR DESCRIPTION
**Changes:**
- Wayfinder v2.1.1
- Management Cluster EKS v1.25
- AWS EBS CSI Driver v1.19.0-eksbuild.2
- CoreDNS v1.9.3-eksbuild.5
- Kube Proxy v1.25.9-eksbuild.1
- VPC CNI v1.12.6-eksbuild.2